### PR TITLE
fix: Docker file run.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN chmod +x /app/run.sh
 
 EXPOSE 5000
 
-CMD ["/app/run.sh"]
+CMD ["sh", "/app/run.sh"]


### PR DESCRIPTION
Ajuste o Dockerfile para poder rodar o run.sh sem precisar do bash